### PR TITLE
added support for arm-linux-gnueabihf- in cross-compile tool check

### DIFF
--- a/peda-arm.py
+++ b/peda-arm.py
@@ -38,7 +38,7 @@ class Asm(AsmBase):
     def __init__(self):
         # Check cross compile toolchains
         PREFIXES = "arm-none-eabi- arm-eabi- arm-androideabi- arm-none-linux-gnueabi- arm-linux-androideabi- " \
-                   "arm-linux-android- arm-linux-eabi- arm-linux-gnueabi-"
+                   "arm-linux-android- arm-linux-eabi- arm-linux-gnueabi- arm-linux-gnueabihf-"
         prefix = ''
         for i in PREFIXES.split():
             command = "%sobjdump" % i


### PR DESCRIPTION
This commit allows detection of arm-linux-gnueabihf- cross-compile tools. For example, this toolchain is used when using a x86_64 host system to cross compile the raspberry pi 3 kernel.