### PR TITLE
fix(peda-arm): use raw strings to avoid regex escape sequence warnings

### DIFF
--- a/peda-arm.py
+++ b/peda-arm.py
@@ -176,7 +176,7 @@ class Asm:
 
         shellcode = []
         # '   0:   e49df004        pop     {pc}            ; (ldr pc, [sp], #4)'
-        pattern = re.compile("\s*([0-9a-f]+):\s*([0-9a-f]+)(.+)")
+        pattern = re.compile(r"\s*([0-9a-f]+):\s*([0-9a-f]+)(.+)")
 
         # matches = pattern.findall(asmcode)
         for line in asmcode.splitlines():
@@ -252,7 +252,7 @@ class ArmPEDACmd(PEDACmd):
 
         if argc is None:
             # deal with regs
-            p = re.compile(":\s*(\S+)\s*(\w+),")
+            p = re.compile(r":\s*(\S+)\s*(\w+),")
             matches = p.findall(code)
             m = [r for (_, r) in matches]
 
@@ -270,7 +270,7 @@ class ArmPEDACmd(PEDACmd):
             else:
                 argc = 0
                 #  '0x8d08: str     r3, [sp, #20]'
-                p = re.compile(":\s*str\s*\S+,\s*\[sp.*#(.*)\]")
+                p = re.compile(r":\s*str\s*\S+,\s*\[sp.*#(.*)\]")
                 matches = p.findall(code)
                 if matches:
                     l = len(matches)
@@ -589,7 +589,7 @@ class ArmPEDACmd(PEDACmd):
                 return None
 
         # inst='=> 0xaf130bd4:\tcbz\tr0, 0xaf130be4'
-        match = re.match('.*:\s+cb(n?z)?\s+(\S+),\s*(\S+)', inst)
+        match = re.match(r'.*:\s+cb(n?z)?\s+(\S+),\s*(\S+)', inst)
         if not match:
             return None
         cond, r, next_addr = match.groups()

--- a/peda/core.py
+++ b/peda/core.py
@@ -1554,7 +1554,7 @@ class PEDA(object):
             - entry address (Int)
         """
         out = PEDA.execute_redirect("info files")
-        p = re.compile("Entry point: (\S*)")
+        p = re.compile(r"Entry point: (\S*)")
         if out:
             m = p.search(out)
             if m:
@@ -1582,7 +1582,7 @@ class PEDA(object):
         if not out:
             return {}
 
-        p = re.compile("^ *\S+ +(0x[^-]+)->(0x[^ ]+) at (\S+): +(\S+) +(.*)$", re.M)
+        p = re.compile(r"^ *\S+ +(0x[^-]+)->(0x[^ ]+) at (\S+): +(\S+) +(.*)$", re.M)
         matches = p.findall(out)
 
         for (start, end, offset, hname, attr) in matches:
@@ -2152,7 +2152,7 @@ class PEDACmd(object):
         fdlist = os.listdir("/proc/%d/fd" % pid)
         for fd in fdlist:
             rpath = os.readlink("/proc/%d/fd/%s" % (pid, fd))
-            sock = re.search("socket:\[(.*)\]", rpath)
+            sock = re.search(r"socket:\[(.*)\]", rpath)
             if sock:
                 spath = execute_external_command("netstat -aen | grep %s" % sock.group(1))
                 if spath:
@@ -2162,11 +2162,11 @@ class PEDACmd(object):
         # uid/gid, pid, ppid
         info["pid"] = pid
         status = open("/proc/%d/status" % pid).read()
-        ppid = re.search("PPid:\s*([^\s]*)", status).group(1)
+        ppid = re.search(r"PPid:\s*([^\s]*)", status).group(1)
         info["ppid"] = to_int(ppid) if ppid else -1
-        uid = re.search("Uid:\s*([^\n]*)", status).group(1)
+        uid = re.search(r"Uid:\s*([^\n]*)", status).group(1)
         info["uid"] = [to_int(id) for id in uid.split()]
-        gid = re.search("Gid:\s*([^\n]*)", status).group(1)
+        gid = re.search(r"Gid:\s*([^\n]*)", status).group(1)
         info["gid"] = [to_int(id) for id in gid.split()]
 
         options = ["exe", "fd", "pid", "ppid", "uid", "gid"]

--- a/peda/utils.py
+++ b/peda/utils.py
@@ -553,7 +553,7 @@ def format_disasm_code(code, nearby=None):
         else:
             color = style = None
             prefix = line.split(":\t")[0]
-            addr = re.search("(0x\S*)", prefix)
+            addr = re.search(r"(0x\S*)", prefix)
             if addr:
                 addr = to_int(addr.group(1))
             else:
@@ -627,7 +627,7 @@ def format_disasm_code_arm(code, nearby=None):
                     break
 
             prefix = line.split(":\t")[0]
-            addr = re.search("(0x\S*)", prefix)
+            addr = re.search(r"(0x\S*)", prefix)
             if addr:
                 addr = to_int(addr.group(1))
             else:
@@ -702,7 +702,7 @@ def format_disasm_code_intel(code, nearby=None):
                     break
 
             prefix = line.split(":\t")[0]
-            addr = re.search("(0x\S*)", prefix)
+            addr = re.search(r"(0x\S*)", prefix)
             if addr:
                 addr = to_int(addr.group(1))
             else:


### PR DESCRIPTION
Converted regex patterns to raw strings to fix SyntaxWarnings on Python 3.11+.